### PR TITLE
feat: Implement FTUE - El Descenso Inevitable

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -283,6 +283,9 @@ const ALL_GAME_FURY_ABILITIES_BASE: FuryAbility[] = [
   { id: 'fury_vigor_momentaneo', name: "Vigor Momentáneo", description: "Enemigo recupera <strong>3 HP</strong>.", icon: "💪❤️", effectType: FuryAbilityEffectType.EnemyHeal, value: 3, rarity: Rarity.Common },
   { id: 'fury_resistencia_impia', name: "Resistencia Impía", description: "Enemigo gana <strong>5 Armadura</strong> temporal.", icon: "🛡️👿", effectType: FuryAbilityEffectType.EnemyGainArmor, value: 5, rarity: Rarity.Rare },
   { id: 'fury_festin_oscuro', name: "Festín Oscuro", description: "Enemigo recupera <strong>5 HP</strong> y su Furia se carga un <strong>25%</strong>.", icon: "🍽️👿", effectType: FuryAbilityEffectType.EnemyHealAndFuryCharge, value: { heal: 5, furyChargePercent: 0.25 }, rarity: Rarity.Epic },
+  // FTUE Sentinel Furies
+  { id: 'fury_ftue_sentinel_level3', name: "Mirada Penetrante", description: "El Centinela te inflige <strong>1 daño</strong> y revela una casilla aleatoria (revelación no implementada en este efecto aún).", icon: "👁️‍🗨️⚡", effectType: FuryAbilityEffectType.PlayerDamage, value: 1, rarity: Rarity.Common },
+  { id: 'fury_ftue_sentinel_level4', name: "Acometida Resonante", description: "El Centinela te inflige <strong>2 daños</strong>.", icon: "👁️‍🗨️⚡⚡", effectType: FuryAbilityEffectType.PlayerDamage, value: 2, rarity: Rarity.Common },
 ];
 
 /** Comprehensive list of all Fury abilities in the game, ensuring no duplicates by ID. */

--- a/constants/difficultyConstants.ts
+++ b/constants/difficultyConstants.ts
@@ -144,6 +144,17 @@ export const ENEMY_ARCHETYPE_DEFINITIONS: Record<EnemyArchetypeId, EnemyArchetyp
     aiType: AIType.Default, 
     isSpecial: true, 
   },
+  [EnemyArchetypeId.CentinelaDelAbismoFTUE]: {
+    id: EnemyArchetypeId.CentinelaDelAbismoFTUE,
+    name: "Centinela del Abismo (FTUE)",
+    icon: "🛡️💧", // Placeholder icon
+    baseHp: 4, // Fixed HP for FTUE Level 2
+    hpPerLevelMultiplier: 0, // No scaling for this FTUE instance
+    baseFuryActivationThreshold: 10, // Example: FTUE Lvl 2 Fury Threshold (GDD: 10 clicks)
+    aiType: AIType.Default, // "Cazador Paciente" (Default AI is a placeholder)
+    isSpecial: true,
+    // No preferred board/density/ratio keys as FTUE boards are typically predefined
+  },
 };
 
 // --- Rank Definitions ---

--- a/screens/PostLevelScreen.tsx
+++ b/screens/PostLevelScreen.tsx
@@ -21,7 +21,8 @@ const PostLevelScreen: React.FC<PostLevelScreenProps> = ({ gameEngine }) => {
     fullActiveEcos, 
     gameState,
     resolveCorazonDelAbismoChoice,
-    setGameStatus, 
+    setGameStatus,
+    metaProgress, // Added metaProgress
   } = gameEngine;
 
   const [processingSelectionEchoId, setProcessingSelectionEchoId] = useState<string | null>(null);
@@ -79,44 +80,53 @@ const PostLevelScreen: React.FC<PostLevelScreenProps> = ({ gameEngine }) => {
 
   const activeEchoIdsFromPlayerActiveEcos: ActiveEchoId[] = activeEcos.map(e => e.id); 
   const currentCorazonOptions = gameState.corazonDelAbismoOptions;
-
+  const isFTUERun = metaProgress.hasCompletedFirstRun === false;
 
   return (
     <div className="flex flex-col items-center justify-center p-4 w-full min-h-[80vh]">
-      <div className="mb-6 text-center">
-        <h2 className="text-3xl font-bold text-green-400">¡Nivel {gameState.currentLevel} Superado!</h2>
-        <p className="text-slate-300 mt-1" id="postLevelMessage">
-          {gameState.isCorazonDelAbismoChoiceActive
-            ? "El Corazón del Abismo exige una ofrenda..."
-            : "Los Ecos de la batalla resuenan. Elige tu bendición."}
-        </p>
-      </div>
-
-      {fullActiveEcos.length > 0 && (
-        <div className="mb-6 w-full max-w-3xl p-3 bg-slate-700/60 rounded-lg shadow-md">
-           <EchoesDisplay
-              activeEcos={fullActiveEcos} 
-              player={player}
-              conditionalEchoTriggeredId={gameState.conditionalEchoTriggeredId}
-            />
+      {isFTUERun ? (
+        <div className="text-center">
+          <h2 className="text-3xl font-bold text-slate-200">El descenso continúa...</h2>
+          <p className="text-xl text-slate-400 mt-2">Siguiente Nivel: {gameState.currentLevel + 1}</p>
         </div>
-      )}
-
-      {gameState.isCorazonDelAbismoChoiceActive && currentCorazonOptions ? (
-        <CorazonDelAbismoChoiceUI
-          {...currentCorazonOptions} 
-          onChoice={handleCorazonChoice}
-          playerGold={player.gold}
-        />
       ) : (
-        <EchoSelectionUI
-          echoOptions={availableEchoChoices}
-          player={player} 
-          onSelectEcho={handleEchoSelection}
-          activeEcos={activeEchoIdsFromPlayerActiveEcos} 
-          isUiDisabled={processingSelectionEchoId !== null || gameState.isFuryMinigameActive || gameState.isCorazonDelAbismoChoiceActive}
-          animatingEchoId={processingSelectionEchoId}
-        />
+        <>
+          <div className="mb-6 text-center">
+            <h2 className="text-3xl font-bold text-green-400">¡Nivel {gameState.currentLevel} Superado!</h2>
+            <p className="text-slate-300 mt-1" id="postLevelMessage">
+              {gameState.isCorazonDelAbismoChoiceActive
+                ? "El Corazón del Abismo exige una ofrenda..."
+                : "Los Ecos de la batalla resuenan. Elige tu bendición."}
+            </p>
+          </div>
+
+          {fullActiveEcos.length > 0 && (
+            <div className="mb-6 w-full max-w-3xl p-3 bg-slate-700/60 rounded-lg shadow-md">
+              <EchoesDisplay
+                activeEcos={fullActiveEcos}
+                player={player}
+                conditionalEchoTriggeredId={gameState.conditionalEchoTriggeredId}
+              />
+            </div>
+          )}
+
+          {gameState.isCorazonDelAbismoChoiceActive && currentCorazonOptions ? (
+            <CorazonDelAbismoChoiceUI
+              {...currentCorazonOptions}
+              onChoice={handleCorazonChoice}
+              playerGold={player.gold}
+            />
+          ) : (
+            <EchoSelectionUI
+              echoOptions={availableEchoChoices}
+              player={player}
+              onSelectEcho={handleEchoSelection}
+              activeEcos={activeEchoIdsFromPlayerActiveEcos}
+              isUiDisabled={processingSelectionEchoId !== null || gameState.isFuryMinigameActive || gameState.isCorazonDelAbismoChoiceActive}
+              animatingEchoId={processingSelectionEchoId}
+            />
+          )}
+        </>
       )}
     </div>
   );

--- a/types.ts
+++ b/types.ts
@@ -198,6 +198,8 @@ export enum EnemyArchetypeId {
   Centinela = 'centinela',
   /** Special prologue enemy. */
   ShadowEmber = 'shadow_ember_prologue',
+  /** FTUE Level 2 enemy. */
+  CentinelaDelAbismoFTUE = 'centinela_del_abismo_ftue',
 }
 
 /**
@@ -1197,6 +1199,8 @@ export interface MetaProgressState {
   furyAwakeningProgress: number;
   /** Index in the `FURY_ABILITIES_TO_AWAKEN_SEQUENTIALLY` array, indicating the next Fury to awaken. */
   nextFuryToAwakenIndex: number;
+  /** True if the player has completed the initial FTUE run (Descenso Inevitable). */
+  hasCompletedFirstRun: boolean;
   /** True if the player has not visited the Sanctuary yet (used for FTUE). */
   firstSanctuaryVisit: boolean;
 }


### PR DESCRIPTION
I've implemented the new First Time User Experience (FTUE) as per GDD v2.0.

This feature introduces a guided first run for you, designed to be an infinite descent, teaching core mechanics through direct experience and culminating in a scripted defeat. This defeat transitions into a tutorial for the Sanctuary and the Mirror of Self.

Key changes:

Sprint FTUE-1: El Modo "Primera Run"
- TASK-FTUE-001: I added `hasCompletedFirstRun` (boolean) to `MetaProgressState` in `types.ts`. I also updated `getInitialMetaProgress` in `useGameEngine.ts` to initialize it to `false` and `loadMetaProgress` to handle it.
- TASK-FTUE-002: I modified `services/encounterGenerator.ts` to generate linear, FTUE-specific encounters if `hasCompletedFirstRun` is false:
    - Level 1: "Fragmento Resonante" (adapted from ShadowEmber) with 2 HP, Cazador Paciente AI (Default), and "Chispa Agónica" Fury.
    - Level 2: "Centinela del Abismo (FTUE)" (new archetype `CentinelaDelAbismoFTUE`) with 4 HP, Cazador Paciente AI (Default), and "Toque del Vacío" Fury.
    - Level 3+: Scaling "Centinela" enemies with evolving AI (Default to Calculator) and progressively stronger fixed Furies. HP scaling is slower.
- TASK-FTUE-003: I modified `generateBoardFromBoardParameters` in `hooks/useGameEngine.ts`. If `hasCompletedFirstRun` is false, boards now exclusively contain `CellType.Attack` and `CellType.Clue` cells. Gold and Traps are not placed. Density starts low and scales as per FTUE design.
- TASK-FTUE-004: I modified `screens/PostLevelScreen.tsx` and `hooks/useGameEngine.ts`. If `hasCompletedFirstRun` is false:
    - Echo selection and the Oracle Minigame are skipped.
    - `PostLevelScreen.tsx` displays "El descenso continúa..." and the next level number.
    - `useGameEngine.ts` logic ensures automatic progression to the next level.

Sprint FTUE-2: El Tutorial Contextual y la Derrota Guiada (Tasks TASK-FTUE-005 to TASK-FTUE-008 were part of the original plan but I didn't explicitly implement them in this series of changes as per the GDD's breakdown by sprint. These would involve creating `FTUEManager.ts`, `GuidingTooltip.tsx`, specific EndScreen modifications for FTUE defeat, and setting `hasCompletedFirstRun = true` post-FTUE EndScreen.)

Sprint FTUE-3: El Onboarding al Santuario
(Tasks TASK-FTUE-009 to TASK-FTUE-011 were part of the original plan but I didn't explicitly implement them in this series of changes. These would cover guided navigation to the Sanctuary and Mirror, and the first upgrade.)

This work primarily focuses on establishing the "infinite descent" mechanics for your first run (Sprint FTUE-1 tasks). The remaining FTUE sprints covering guided tooltips, special defeat screen, and Sanctuary onboarding will be implemented separately.